### PR TITLE
templates: Replace exit with raise exception

### DIFF
--- a/generate/templates/device.py.in
+++ b/generate/templates/device.py.in
@@ -33,10 +33,8 @@ class PingDevice(object):
             self.iodev.send_break()
             self.iodev.write("U".encode("utf-8"))
 
-        except Exception as e:
-            print("Failed to open the given serial port")
-            print("\t", e)
-            exit(1)
+        except Exception as exception:
+            raise Exception("Failed to open the given serial port: {0}".format(exception))
 
         ## A helper class to take care of decoding the input stream
         self.parser = pingmessage.PingParser()


### PR DESCRIPTION
This creates issues when the class is used and the error handle can be done in the main logic

Fix #75 

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>