### PR TITLE
setup.py: make python3 a requirement (PEP440)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ Blue Robotics Ping Echosounder and Ping360 scanning sonar.
 
 setup(name='bluerobotics-ping',
       version='0.1.0',
+      python_requires='>=3.4',
       description='A python module for the Blue Robotics ping-protocol and products',
       long_description=long_description,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
Fix #92 

Done accordingly to https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires