### PR TITLE
brping: pingmessage: Fix payload_length check

### DIFF
--- a/brping/pingmessage.py
+++ b/brping/pingmessage.py
@@ -350,7 +350,7 @@ class PingParser(object):
     def wait_dst_id(self, msg_byte):
         self.buf.append(msg_byte)
         self.state += 1
-        if self.payload_length == 1: # no payload bytes -> skip waiting
+        if self.payload_length == 0: # no payload bytes -> skip waiting
             self.state += 1
 
     def wait_payload(self, msg_byte):


### PR DESCRIPTION
This should be zero and not one, the error was introduced in a rework on #110:
https://github.com/bluerobotics/ping-python/pull/110/files#diff-ed2c04d88418d534a1ae078d8a994d08848d370ca71de0d0af5ab5f7b6f19d99R345

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>