### PR TITLE
CI: fix version extraction from setup.py

### DIFF
--- a/.github/workflows/deploy_to_pypi.yml
+++ b/.github/workflows/deploy_to_pypi.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Check Tag and setup.py Version Match
       run: |
         TAG_VERSION=${GITHUB_REF#refs/tags/v}
-        SETUP_VERSION=$(grep -oE "version='([^']+)" setup.py | grep -oE '[^=]+$')
+        SETUP_VERSION=$(grep -oE "version='([^']+)" setup.py | grep -oE "[^'=]+$")
         if [[ "$TAG_VERSION" != "$SETUP_VERSION" ]]; then
           echo "Tag version $TAG_VERSION does not match setup.py version $SETUP_VERSION."
           exit 1


### PR DESCRIPTION
```
➜  ping-python git:(fix_version_check) ✗ SETUP_VERSION=$(grep -oE "version='([^']+)" setup.py | grep -oE "[^'=]+$")
➜  ping-python git:(fix_version_check) ✗ echo $SETUP_VERSION                                                       
0.1.5
```