### PR TITLE
docs: remove unnecessary content

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,6 +1,7 @@
 __pycache__
 _build
-source/python_api
+source/python_api/*
+!/source/python_api/index.rst
 source/cpp_api
 source/lua_api
 **.pyc

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,5 @@
+/* Hide third level of secondary sidebar onwards */
+.md-sidebar--secondary .md-nav__list .md-nav__list .md-nav__list {
+    display: none;
+  }
+  

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,7 +39,7 @@ extensions = [
 ]
 master_doc = "index"
 source_suffix = {'.rst': 'restructuredtext', '.md': 'restructuredtext'}
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "python_api/library_root.rst"]
 
 # Syntax highlighting
 pygments_style = "sphinx"
@@ -57,6 +57,8 @@ extlinks = {
 # HTML output configuration
 html_theme = "sphinx_blue_robotics_theme"
 html_static_path = ["_static"]
+html_css_files = ['custom.css']
+
 html_theme_options = {
     "site_url": SITE_URL,
     "repo_url": REPO_URL,
@@ -124,8 +126,10 @@ exhale_args = {
     "rootFileName":          "library_root.rst",
     "doxygenStripFromPath":  root_path,
     "rootFileTitle":         "API Reference",
-    "createTreeView":        True,
+    "createTreeView":        False,
+    "contentsDirectives":    False,
     "exhaleExecutesDoxygen": True,
+    "fullToctreeMaxDepth": 1,
     "exhaleDoxygenStdin":    f"INPUT = {os.path.join(root_path, 'brping')}",
     "verboseBuild":          True,
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,4 +8,4 @@ A python implementation of the Blue Robotics Ping messaging protocol and a devic
   :maxdepth: 2
   :caption: Contents:
 
-  python_api/library_root
+  python_api/index

--- a/docs/source/python_api/index.rst
+++ b/docs/source/python_api/index.rst
@@ -1,0 +1,8 @@
+=============
+API Reference
+=============
+
+
+.. include:: unabridged_api.rst.include
+    :start-after: --------
+


### PR DESCRIPTION
**Changes:**

- Removes file hierarchy views
- Limits toctree level to one
- Limits right sidebar to two levels
- Removes one level (Full API) in the main sidebar

**Preview:**

![image](https://github.com/user-attachments/assets/c817ff1f-722a-4959-9281-0908bf82b8ee)

![image](https://github.com/user-attachments/assets/b51137a1-b631-4b92-b2a1-81584d750621)



