### PR TITLE
Improve failed connection behavior. Fix bugs in Surveyor 240 template. 

### DIFF
--- a/generate/templates/omniscan450.py.in
+++ b/generate/templates/omniscan450.py.in
@@ -311,7 +311,7 @@ class Omniscan450(PingDevice):
     # @param host: TCP server address (IPV4) or name
     # @param port: port used to connect with server
     #
-    def connect_tcp(self, host: str = None, port: int = 12345):
+    def connect_tcp(self, host: str = None, port: int = 12345, timeout: float = 5.0):
         if host is None:
             host = '0.0.0.0'
         
@@ -319,9 +319,13 @@ class Omniscan450(PingDevice):
         try:
             print("Opening %s:%d" % self.server_address)
             self.iodev = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.iodev.settimeout(timeout)
             self.iodev.connect(self.server_address)
             self.iodev.setblocking(0)
-        
+            
+        except socket.timeout:
+            print("Unable to connect to device")
+            raise Exception("Connection timed out after {0} seconds".format(timeout))          
         except Exception as exception:
             raise Exception("Failed to open the given TCP port: {0}".format(exception))
 

--- a/generate/templates/s500.py.in
+++ b/generate/templates/s500.py.in
@@ -115,7 +115,7 @@ class S500(PingDevice):
     # @param host: TCP server address (IPV4) or name
     # @param port: port used to connect with server
     #
-    def connect_tcp(self, host: str = None, port: int = 12345):
+    def connect_tcp(self, host: str = None, port: int = 12345, timeout: float = 5.0):
         if host is None:
             host = '0.0.0.0'
         
@@ -123,9 +123,13 @@ class S500(PingDevice):
         try:
             print("Opening %s:%d" % self.server_address)
             self.iodev = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.iodev.settimeout(timeout)
             self.iodev.connect(self.server_address)
             self.iodev.setblocking(0)
-        
+
+        except socket.timeout:
+            print("Unable to connect to device")
+            raise Exception("Connection timed out after {0} seconds".format(timeout))         
         except Exception as exception:
             raise Exception("Failed to open the given TCP port: {0}".format(exception))
 

--- a/generate/templates/surveyor240.py.in
+++ b/generate/templates/surveyor240.py.in
@@ -11,6 +11,7 @@
 from brping import definitions
 from brping import PingDevice
 from brping import pingmessage
+import math
 import time
 import struct
 import socket
@@ -109,6 +110,11 @@ class Surveyor240(PingDevice):
 
     def readDeviceInformation(self):
         return self.request(definitions.COMMON_DEVICE_INFORMATION)
+
+    # Calculate the milliseconds per ping from a ping rate
+    @staticmethod
+    def calc_msec_per_ping(ping_rate):
+        return math.floor(1000.0 / ping_rate)
 
     def get_utc_time(self):
         clock_offset = 0

--- a/generate/templates/surveyor240.py.in
+++ b/generate/templates/surveyor240.py.in
@@ -315,7 +315,7 @@ class Surveyor240(PingDevice):
     # @param host: TCP server address (IPV4) or name
     # @param port: port used to connect with server
     #
-    def connect_tcp(self, host: str = None, port: int = 12345):
+    def connect_tcp(self, host: str = None, port: int = 12345, timeout: float = 5.0):
         if host is None:
             host = '0.0.0.0'
         
@@ -323,9 +323,13 @@ class Surveyor240(PingDevice):
         try:
             print("Opening %s:%d" % self.server_address)
             self.iodev = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.iodev.settimeout(timeout)
             self.iodev.connect(self.server_address)
             self.iodev.setblocking(0)
-        
+
+        except socket.timeout:
+            print("Unable to connect to device")
+            raise Exception("Connection timed out after {0} seconds".format(timeout))        
         except Exception as exception:
             raise Exception("Failed to open the given TCP port: {0}".format(exception))
 


### PR DESCRIPTION
If the wrong IP address or port was entered, or if the device couldn't be connected, the examples would get stuck with no way to exit. 