### PR TITLE
generate: templates: device.py: use exclusive flag for opening ports

### DIFF
--- a/generate/templates/device.py.in
+++ b/generate/templates/device.py.in
@@ -49,7 +49,9 @@ class PingDevice(object):
             ## Serial object for device communication
             # write_timeout fixes it getting stuck forever atempting to write to
             # /dev/ttyAMA0 on Raspberry Pis, this raises an exception instead.
-            self.iodev = serial.Serial(device_name, baudrate, write_timeout=1.0)
+            # exclusive=True ensures that we don't get stuck due to multiple processes
+            # trying to access the same serial port.
+            self.iodev = serial.Serial(device_name, baudrate, write_timeout=1.0, exclusive=True)
             try:
                 self.iodev.set_low_latency_mode(True)
             except Exception as exception:


### PR DESCRIPTION
Fixes an issue in BlueOS where our prober gets stuck trying to open the serial port.

before:
<img width="1161" height="301" alt="image" src="https://github.com/user-attachments/assets/47dee500-0a9e-4333-a6f3-9644d89e933c" />

after:
<img width="1323" height="489" alt="image" src="https://github.com/user-attachments/assets/597e96ba-8740-4d8b-b344-204975cf3d84" />
