### PR TITLE
Update ping-protocol submodule & regenerate definitions.py with correct OMNISCAN450_SET_SPEED_OF_SOUND id

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/ping-protocol"]
 	path = lib/ping-protocol
-	url = https://github.com/bluerobotics/ping-protocol
+	url = https://github.com/maexerich/ping-protocol


### PR DESCRIPTION
_This is my first PR on a open-source codebase. I used AI to navigate the process but have manually reviewed everything to the best of my knowledge._

## Summary
This PR:
1. Updates the `lib/ping-protocol` submodule reference to use the fixed protocol definitions
2. Regenerates `brping/definitions.py` with the corrected message ID (although not tracked by git).

## Related Fix
Depends on: bluerobotics/ping-protocol# at commit hash: 629510

## Changes
- **`.gitmodules`**: Updated submodule URL to point to fixed ping-protocol fork temporarily
- **`lib/ping-protocol`**: Now references commit with corrected OMNISCAN450_SET_SPEED_OF_SOUND ID
(- **`brping/definitions.py`**: Regenerated; now contains `OMNISCAN450_SET_SPEED_OF_SOUND = 116`) (not tracked by git)

## How This Was Generated
```bash
git submodule update --remote
git -C lib/ping-protocol checkout fix/omniscan450-speed-of-sound
python generate/generate-python.py --output-dir brping