### PR TITLE
Fix input buffer for multiple Omniscan operation

### DIFF
--- a/generate/templates/device.py.in
+++ b/generate/templates/device.py.in
@@ -20,8 +20,10 @@ class PingDevice(object):
     _{{field}} = None
 {% endfor%}
 
-    _input_buffer = deque()
     def __init__(self, payload_dict=None):
+        ## Receive buffer for this device's io stream.
+        self._input_buffer = deque()
+
         my_payload_dict = {}
         if payload_dict is not None:
             my_payload_dict = definitions.payload_dict_common.copy()


### PR DESCRIPTION
### Summary
There have been reports of issues when using two Omniscan 450s that the data that comes from the incorrect Omniscan and data "swaps sides". After looking at the code. each Device instance shares the same input buffer. I adjusted the template so that the generated code creates a new input buffer instance for each new device.
<img width="1307" height="240" alt="image (3)" src="https://github.com/user-attachments/assets/8d9f3150-fe71-4e8b-b79d-1aae810b3244" />

### Changes
Updated device.py.in template to create a new input buffer anytime a new device is initialized

### Note
Change Tested with two Omniscan 450s.